### PR TITLE
fix: stale allowance after dispute token change

### DIFF
--- a/contracts/Disputer.sol
+++ b/contracts/Disputer.sol
@@ -12,6 +12,10 @@ contract Disputer is Ownable {
     Distributor public distributor;
     mapping(address => bool) public whitelist;
 
+    /// @notice Token for which infinite approval was last granted to the distributor
+    /// @dev Tracked explicitly to ensure correct revocation when disputeToken changes
+    address public approvedToken;
+
     /*//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                                                        MODIFIERS                                                    
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////*/
@@ -29,8 +33,11 @@ contract Disputer is Ownable {
     constructor(address _owner, address[] memory _initialWhitelist, Distributor _distributor) {
         distributor = _distributor;
 
-        // Set infinite approval for the distributor
-        IERC20(_distributor.disputeToken()).approve(address(_distributor), type(uint256).max);
+        // Set infinite approval for the distributor and track the approved token
+        address _disputeToken = address(_distributor.disputeToken());
+        approvedToken = _disputeToken;
+        IERC20(_disputeToken).approve(address(_distributor), type(uint256).max);
+
         uint256 length = _initialWhitelist.length;
         for (uint256 i; i < length; ) {
             whitelist[_initialWhitelist[i]] = true;
@@ -100,10 +107,13 @@ contract Disputer is Ownable {
     /// @dev Only the owner can set the distributor
     /// @param _distributor Distributor to set
     function setDistributor(Distributor _distributor) external onlyOwner {
-        // Remove approval from old distributor
-        IERC20(distributor.disputeToken()).approve(address(distributor), 0);
+        // Revoke approval using the tracked approvedToken, not distributor.disputeToken()
+        // which may have changed since the approval was granted
+        IERC20(approvedToken).approve(address(distributor), 0);
         distributor = _distributor;
-        // Set infinite approval for new distributor
-        IERC20(_distributor.disputeToken()).approve(address(_distributor), type(uint256).max);
+        // Set infinite approval for new distributor and update tracked token
+        address _newDisputeToken = address(_distributor.disputeToken());
+        approvedToken = _newDisputeToken;
+        IERC20(_newDisputeToken).approve(address(_distributor), type(uint256).max);
     }
 }

--- a/test/unit/Disputer.t.sol
+++ b/test/unit/Disputer.t.sol
@@ -9,6 +9,7 @@ import { Disputer } from "../../contracts/Disputer.sol";
 import { DistributorTest } from "./Distributor.t.sol";
 import { IAccessControlManager } from "../../contracts/interfaces/IAccessControlManager.sol";
 import { Errors } from "../../contracts/utils/Errors.sol";
+import { MockTokenPermit } from "../../contracts/mock/MockTokenPermit.sol";
 
 contract DisputerTest is DistributorTest {
     Disputer public disputer;
@@ -137,5 +138,32 @@ contract DisputerTest is DistributorTest {
         vm.expectRevert(Errors.WithdrawalFailed.selector);
         disputer.withdrawFunds(payable(governor), amount);
         vm.stopPrank();
+    }
+
+    function test_setDistributor_leavesStaleAllowance() public {
+        // Step 1: Check initial approval - Disputer approved tokenA (angle) for distributor1
+        address tokenA = address(distributor.disputeToken());
+        uint256 allowanceBefore = IERC20(tokenA).allowance(address(disputer), address(distributor));
+        assertGt(allowanceBefore, 0, "Initial allowance should be infinite");
+
+        // Step 2: Governor changes disputeToken on old distributor to tokenB
+        MockTokenPermit tokenB = new MockTokenPermit("TokenB", "TB", 18);
+        vm.prank(governor);
+        distributor.setDisputeToken(IERC20(address(tokenB)));
+
+        // Step 3: Deploy new distributor with tokenB
+        Distributor distributorImpl2 = new Distributor();
+        Distributor distributor2 = Distributor(deployUUPS(address(distributorImpl2), hex""));
+        vm.startPrank(governor);
+        distributor2.initialize(IAccessControlManager(address(accessControlManager)));
+        distributor2.setDisputeToken(IERC20(address(tokenB)));
+
+        // Step 4: Call setDistributor - this will revoke tokenB approval, not tokenA
+        disputer.setDistributor(distributor2);
+        vm.stopPrank();
+
+        // Step 5: Assert stale allowance remains on tokenA for old distributor
+        uint256 staleAllowance = IERC20(tokenA).allowance(address(disputer), address(distributor));
+        assertEq(staleAllowance, 0, "Stale allowance should be zero after fix");
     }
 }


### PR DESCRIPTION
Fix stale allowance when changing distributors.

If the dispute token was updated before setDistributor(), the old distributor
could retain an allowance on the previously approved token.

Track the approved token explicitly and revoke the correct allowance.
Added a regression test for this scenario.