### PR TITLE
ci: bump actions/checkout and actions/setup-node off the retired Node 12/16 runtimes

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup repo
         uses: ./.github/actions/setup-repo
@@ -32,11 +32,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -69,7 +69,7 @@ jobs:
     needs: ['build', 'lint']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup repo
         uses: ./.github/actions/setup-repo
@@ -29,7 +29,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -59,7 +59,7 @@ jobs:
     needs: ['build', 'lint']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 


### PR DESCRIPTION
## What this does

As CONTRIBUTING asks, here is the explanation up front.

The workflows pin `actions/checkout` at `v3` in six places and at `v2` in one, plus `actions/setup-node@v3`. Both majors run on action runtimes GitHub has retired (Node 16 for `v3`, Node 12 for `v2`), so every CI run reports deprecation warnings. This bumps those pins to `v4`:

| file | line | before | after |
|---|---|---|---|
| `.github/workflows/ci.yml` | 14, 32, 62 | `actions/checkout@v3` | `actions/checkout@v4` |
| `.github/workflows/ci-deep.yml` | 17, 35 | `actions/checkout@v3` | `actions/checkout@v4` |
| `.github/workflows/ci-deep.yml` | 39 | `actions/setup-node@v3` | `actions/setup-node@v4` |
| `.github/workflows/ci-deep.yml` | 72 | `actions/checkout@v2` | `actions/checkout@v4` |
| `.github/workflows/coverage.yml` | 9 | `actions/checkout@v3` | `actions/checkout@v4` |

The `v2` pin at `ci-deep.yml:72` (the `foundry-tests` job) is the odd one out — every other checkout in the repository was already a major ahead of it.

`checkout` and `setup-node` are stateless, so the bump carries no behavioural change here: no inputs are added, removed or renamed.

## Deliberately left alone

- **`actions/cache@v3`** in `.github/actions/setup-repo/action.yml`, and the `actions/cache/save@v3` / `actions/cache/restore@v3` steps. Moving cache to `v4` changes the cache backend and invalidates existing entries once. The cache steps currently succeed, so that is a judgement call for you rather than something to slip into a version-bump PR. Happy to add it if you would like it in the same change.
- **`oven-sh/setup-bun@v1`** and **`foundry-rs/foundry-toolchain@v1`** — `v1` is the current major for both, not a stale pin.

## One thing worth flagging separately

The scheduled `ci-deep.yml` runs have been failing at the `Run Foundry tests` step every week since at least 2026-07-12. That is unrelated to action versions and this PR does not touch it — mentioning it only so the existing red run is not read as a regression from this change.

## Verification

All three files parse as YAML with job names unchanged, and each target major exists upstream.
